### PR TITLE
fix(package-ri-pulumi): fix build output

### DIFF
--- a/samples/packages/pulumi-typescript/package.json
+++ b/samples/packages/pulumi-typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openfabr/package-ri-pulumi",
-    "version": "1.0.1",
+    "version": "1.0.0",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "license": "AGPL-3.0-only",

--- a/samples/packages/pulumi-typescript/package.json
+++ b/samples/packages/pulumi-typescript/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openfabr/package-ri-pulumi",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "license": "AGPL-3.0-only",

--- a/samples/packages/pulumi-typescript/tsconfig.json
+++ b/samples/packages/pulumi-typescript/tsconfig.json
@@ -29,7 +29,7 @@
       "outDir": "dist",
     },
     "include": [
-      "src", "tests"
+      "src"
     ],
     "exclude": [
       "node_modules",


### PR DESCRIPTION
## Description
Build output is `dist` folder has `src` and `test` at the root. Rather the build output of the source code in `src` should output into the root of `dist`.

Cause: `tests` was incorrectly an`include` in tsconfig causing the build output to be broken.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] manually run the build and check that the `dist` folder no longer has `src` and `test` folder in the root.
- [x] make sure jest tests all pass

**Test Configuration**:

Please describe the test setup. List them below as bullet points.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] The commit message follows the convention of this project