### PR TITLE
fix(Pulumi RI): remove `neverthrow` reference

### DIFF
--- a/samples/packages/pulumi-typescript/package-lock.json
+++ b/samples/packages/pulumi-typescript/package-lock.json
@@ -9,8 +9,7 @@
             "version": "1.1.0",
             "license": "AGPL-3.0-only",
             "dependencies": {
-                "@openfabr/cdf": "^2.0.0",
-                "neverthrow": "^5.0.1"
+                "@openfabr/cdf": "^2.0.0"
             },
             "devDependencies": {
                 "@types/jest": "^29.2.4",

--- a/samples/packages/pulumi-typescript/package.json
+++ b/samples/packages/pulumi-typescript/package.json
@@ -26,8 +26,7 @@
         "ts-jest": "^29.0.3"
     },
     "dependencies": {
-        "@openfabr/cdf": "^2.0.0",
-        "neverthrow": "^5.0.1"
+        "@openfabr/cdf": "^2.0.0"
     },
     "peerDependencies": {
         "@pulumi/aws": "^5.0.0",


### PR DESCRIPTION
## Description

This was caused a type mismatch error in the consuming Project. The `InitComponent` didn't like the type
retruned by the `Planner` class.

Fixes/Implements #(issue/feature)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Jest tests pass
- manual test: installed the package in the sample project (on a different branch) by local path reference. Was able to recreate the problem this way. Removed the `neverthrow` reference  on the Pulumi sample Package. And the type mismatch error in the project disappeared. was able to successfully run a `pulumi preview`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] The commit message follows the convention of this project