### PR TITLE
feat(core)!: improve `command` field for cdf manifest

### DIFF
--- a/core/typescript/README.md
+++ b/core/typescript/README.md
@@ -20,4 +20,6 @@ Release:
 - Available in main NPM registry as `@openfabr/cdf`
 - Available as both CommonJS and ES6 modules
 
-*Credit goes to [Typescript Starter](https://github.com/bitjson/typescript-starter/) for setting the foundation of this framework.*
+Credits goes to 
+- [Typescript Starter](https://github.com/bitjson/typescript-starter/) for setting the foundation of this framework
+- [Release Please](https://github.com/google-github-actions/release-please-action) for supporting the release process

--- a/core/typescript/src/lib/domain.ts
+++ b/core/typescript/src/lib/domain.ts
@@ -26,17 +26,21 @@ export enum CloudVendor {
    */
   GCP = 'GCP',
   /**
-   * Vendor: Digital Ocean
+   * Vendor: DigitalOcean
    */
   DO = 'DO',
   /**
-   * Vendor: CloudFlare
+   * Vendor: Cloudflare
    */
   CF = 'CF',
   /**
    * Vendor: Alibaba Cloud / Aliyun
    */
   ALI = 'ALI',
+  /**
+   * On-premise, usually self-managed infrastructure, including own data centres or own racks, with or without virtualisation.
+   */
+  SELF = 'SELF',
 }
 
 /**
@@ -46,9 +50,25 @@ export enum CloudVendor {
  * @group For both project creators and package authors
  */
 export enum ToolingRuntime {
+  /**
+   * Tooling: AWS CDK, https://aws.amazon.com/cdk/
+   */
   AWSCDK = 'awscdk',
+  /**
+   * Tooling: CDK for Terraform, https://developer.hashicorp.com/terraform/cdktf
+   */
   CDKTF = 'cdktf',
+  /**
+   * Tooling: CDK for K8s, https://cdk8s.io/
+   */
+  CDK8S = 'cdk8s',
+  /**
+   * Tooling: Pulumi, https://www.pulumi.com/
+   */
   PULUMI = 'pulumi',
+  /**
+   * Custom tooling, including other vendors such as Ansible or in-house shell scripts
+   */
   CUSTOM = 'custom',
 }
 
@@ -59,11 +79,33 @@ export enum ToolingRuntime {
  * @group For both project creators and package authors
  */
 export enum ToolingLanguage {
+  /**
+   * Language: TypeScript, https://www.typescriptlang.org/
+   */
   TYPESCRIPT = 'typescript',
+  /**
+   * Language: Python, https://www.python.org/
+   */
   PYTHON = 'python',
+  /**
+   * Language: Java, https://www.java.com/
+   */
   JAVA = 'java',
+  /**
+   * Language: C#, https://learn.microsoft.com/en-us/dotnet/csharp/
+   */
   CSHARP = 'csharp',
+  /**
+   * Language: Go, https://go.dev/
+   */
   GO = 'go',
+  /**
+   * Language: shell scripts, https://en.wikipedia.org/wiki/Shell_script
+   */
+  SHELL = 'shell',
+  /**
+   * Custom (or mixed) solution
+   */
   CUSTOM = 'custom',
 }
 

--- a/core/typescript/src/lib/metadata-minimal.spec.json
+++ b/core/typescript/src/lib/metadata-minimal.spec.json
@@ -4,7 +4,6 @@
   "license": "UNLICENSED",
   "cdf": "1.x",
   "tooling": {
-    "command": "cdktf deploy",
     "runtime": "cdktf",
     "language": "typescript",
     "vendors": [

--- a/core/typescript/src/lib/metadata-normal.spec.json
+++ b/core/typescript/src/lib/metadata-normal.spec.json
@@ -10,7 +10,14 @@
     "phone": "0800123456789"
   },
   "tooling": {
-    "command": "cdktf deploy",
+    "command": {
+      "provision": "cdktf deploy",
+      "destroy": "cdktf destroy",
+      "others": {
+        "logs": "cdktf logs",
+        "info": "cdktf info"
+      }
+    },
     "runtime": "cdktf",
     "language": "typescript",
     "vendors": [

--- a/core/typescript/src/lib/metadata.ts
+++ b/core/typescript/src/lib/metadata.ts
@@ -54,15 +54,37 @@ export interface SupportInfo {
 }
 
 /**
+ * Interface that offers command information about the underlying tooling in the package.
+ *
+ * @group for both project creators and package authors
+ */
+export interface ToolingCommandInfo {
+  /**
+   * The provision command, such as 'cdk deploy' for a typical AWS CDK based package.
+   */
+  readonly provision: string;
+  /**
+   * The destroy command, such as 'cdktf destroy' for a typical CDK for Terraform based package.
+   */
+  readonly destroy: string;
+  /**
+   * The optional list of other available commands made available by a package.
+   */
+  readonly others?: { [key: string]: string };
+}
+
+/**
  * Interface that offers information about IaC tooling.
  *
  * @group For both project creators and package authors
  */
 export interface ToolingInfo {
   /**
-   * The shell command to run deployment with the package.
+   * The information about commands available to manage infra with the package.
+   *
+   * If not present, it is auto-guessed from both `ToolingRuntime` and `ToolingLanguage`; therefore it is recommended to always provide the info.
    */
-  readonly command: string;
+  readonly command?: ToolingCommandInfo;
   /**
    * The supported IaC runtime.
    */


### PR DESCRIPTION
## Description

Given the almost unlimited possibility of underlying IaC toolings and languages supported by CDF, it feels necessary to expand the `command` field in the `tooling` section of the package manifest to include both *provision* and *destroy* commands, plus room for more package-specific commands. 

It is however optional as given a known tooling and/or a language, CDF can usually work out the provision/destroy commands automatically. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor and code improvement (non-breaking change which improves code quality and/or performance)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation
- [ ] Tests
- [ ] Other chores such as maintenance

## How Has This Been Tested?

All tests that were written with sample manifest json files have been updated to accommodate the new manifest format.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] The commit message follows the convention of this project